### PR TITLE
Implement full plugin listing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pandas==2.3.0
 Requests==2.32.3
+openpyxl==3.1.2


### PR DESCRIPTION
## Summary
- prevent infinite loop in `PluginSearcher.search`
- add `PluginLister` for fetching all plugins via API
- support `--all` CLI option for bulk scans
- expand unit tests to cover new code and adjust existing tests
- include missing dependency `openpyxl` for Excel reporting

## Testing
- `pip install -r requirements.txt`
- `python main.py --test`

------
https://chatgpt.com/codex/tasks/task_b_68419162bc40832c852050be58f7d56f