### PR TITLE
Add rule-based scanning

### DIFF
--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,0 +1,25 @@
+import unittest
+from pathlib import Path
+import tempfile
+import shutil
+import re
+
+from wp_plugin_scanner.scanner import RuleScanner, ScanRule
+
+class TestRuleScanner(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        (self.tmp / "plug").mkdir()
+        (self.tmp / "plug/file.php").write_text("<?php dangerous_func(); ?>")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_scan(self):
+        rule = ScanRule("danger", re.compile(rb"dangerous_func"))
+        scanner = RuleScanner([rule])
+        result = scanner.scan(self.tmp / "plug")
+        self.assertTrue(result["danger"])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/wp_plugin_scanner/manager.py
+++ b/wp_plugin_scanner/manager.py
@@ -8,14 +8,14 @@ from typing import Sequence, Callable
 from .config import SAVE_ROOT, DEFAULT_WORKERS
 from .models import PluginResult
 from .downloader import IPluginDownloader
-from .scanner import UploadScanner
+from .scanner import UploadScanner, RuleScanner
 from .reporter import ExcelReporter
 
 class AuditManager:
     def __init__(
         self,
         downloader: IPluginDownloader,
-        scanner: UploadScanner,
+        scanner: RuleScanner,
         reporter: ExcelReporter,
         *,
         save_sources: bool = True,
@@ -45,10 +45,11 @@ class AuditManager:
             return PluginResult(slug, "skipped")
         try:
             tmp_path = self.downloader.download(slug)
-            has_upload = self.scanner.has_upload_feature(tmp_path)
+            scan_results = self.scanner.scan(tmp_path)
             if self.save_sources:
                 self._archive_sources(slug, tmp_path)
-            status = str(has_upload)
+            import json
+            status = json.dumps(scan_results, ensure_ascii=False)
         except Exception as e:
             status = f"error:{e}"
         finally:

--- a/wp_plugin_scanner/scanner.py
+++ b/wp_plugin_scanner/scanner.py
@@ -1,26 +1,42 @@
 import os
+from dataclasses import dataclass
 from pathlib import Path
 import re
+from typing import Sequence, Dict, List
 
 from .config import UPLOAD_PATTERN
 
-class UploadScanner:
-    def __init__(self, pattern: re.Pattern[bytes] = UPLOAD_PATTERN):
-        self.pattern = pattern
+
+@dataclass
+class ScanRule:
+    """Represents a single scan rule defined by a regex pattern."""
+
+    name: str
+    pattern: re.Pattern[bytes]
+
+
+class RuleScanner:
+    """Scanner that evaluates a set of regex based rules."""
+
+    def __init__(self, rules: Sequence[ScanRule]):
+        self.rules: List[ScanRule] = list(rules)
         self.exts = (".php", ".js", ".html", ".twig")
 
-    def has_upload_feature(self, plugin_path: Path) -> bool:
+    def scan(self, plugin_path: Path) -> Dict[str, bool]:
+        results: Dict[str, bool] = {r.name: False for r in self.rules}
         for root, _d, files in os.walk(plugin_path):
             for fname in files:
                 if not fname.lower().endswith(self.exts):
                     continue
                 try:
                     with open(Path(root) / fname, "rb") as f:
-                        if self.pattern.search(f.read()):
-                            return True
+                        data = f.read()
+                        for rule in self.rules:
+                            if not results[rule.name] and rule.pattern.search(data):
+                                results[rule.name] = True
                 except Exception:
                     continue
-        return False
+        return results
 
     def gather_files(self, plugin_path: Path) -> list[Path]:
         collected: list[Path] = []
@@ -29,3 +45,13 @@ class UploadScanner:
                 if fname.lower().endswith(self.exts):
                     collected.append(Path(root) / fname)
         return collected
+
+
+class UploadScanner(RuleScanner):
+    """Backward compatible scanner for upload functionality."""
+
+    def __init__(self, pattern: re.Pattern[bytes] = UPLOAD_PATTERN):
+        super().__init__([ScanRule("upload", pattern)])
+
+    def has_upload_feature(self, plugin_path: Path) -> bool:
+        return self.scan(plugin_path).get("upload", False)

--- a/wp_plugin_scanner/templates/index.html
+++ b/wp_plugin_scanner/templates/index.html
@@ -125,6 +125,13 @@
                 <button class="btn btn-secondary" id="kw-btn" style="margin-bottom:15px;">Fetch Slugs</button>
                 <h3 class="section-title" style="font-size: 16px; margin-top: 15px;">📋 Plugin Slugs</h3>
                 <textarea class="plugin-textarea" id="slug-input" placeholder="contact-form-7, akismet, woocommerce"></textarea>
+                <h3 class="section-title" style="font-size: 16px; margin-top: 15px;">🛠️ Custom Rules</h3>
+                <div id="rules-list" style="margin-bottom:10px;"></div>
+                <div style="display:flex;gap:5px;margin-bottom:15px;">
+                    <input type="text" id="rule-name" placeholder="name" style="flex:1;padding:6px 8px;border:1px solid #ddd;border-radius:4px;">
+                    <input type="text" id="rule-pattern" placeholder="regex" style="flex:2;padding:6px 8px;border:1px solid #ddd;border-radius:4px;">
+                    <button class="btn btn-secondary" type="button" id="add-rule">Add</button>
+                </div>
                 <div class="scan-settings">
                     <h4 style="font-size: 14px; margin-bottom: 12px; font-weight: 600;">⚙️ Scan Settings</h4>
                     <div class="setting-row"><span class="setting-label">Concurrent Workers</span><div class="setting-value"><input type="number" class="number-input" id="workers" value="8" min="1" max="20"></div></div>
@@ -178,6 +185,22 @@ function addResult(row) {
     tr.innerHTML = `<td class="plugin-name">${row.slug}</td><td><span class="status-badge ${row.class}">${row.label}</span></td><td>${row.detail||''}</td><td>${row.time}</td>`;
     tbody.appendChild(tr);
 }
+let rules=[];
+function renderRules(){
+    const list=document.getElementById('rules-list');
+    list.innerHTML='';
+    rules.forEach((r,i)=>{
+        const div=document.createElement('div');
+        div.textContent=r.name+': '+r.pattern;
+        div.style.fontSize='12px';
+        const b=document.createElement('button');
+        b.textContent='❌';
+        b.className='btn-icon';
+        b.onclick=()=>{rules.splice(i,1);renderRules();};
+        div.appendChild(b);
+        list.appendChild(div);
+    });
+}
 function updateStats() {
     const rows = Array.from(document.querySelectorAll('#results-body tr'));
     document.getElementById('stat-total').textContent = rows.length;
@@ -194,7 +217,8 @@ function startScan(){
         timeout:parseInt(document.getElementById('timeout').value)||30,
         retries:parseInt(document.getElementById('retries').value)||3,
         save:document.getElementById('save-sources').checked,
-        skip:document.getElementById('skip-exists').checked
+        skip:document.getElementById('skip-exists').checked,
+        rules:rules
     };
     document.getElementById('results-body').innerHTML='';
     document.getElementById('empty-state').style.display='none';
@@ -229,6 +253,16 @@ function fetchSlugs(){
 }
 document.getElementById('scan-btn').addEventListener('click',startScan);
 document.getElementById('kw-btn').addEventListener('click',fetchSlugs);
+document.getElementById('add-rule').addEventListener('click',()=>{
+    const name=document.getElementById('rule-name').value.trim();
+    const pattern=document.getElementById('rule-pattern').value.trim();
+    if(!name||!pattern)return;
+    rules.push({name:name,pattern:pattern});
+    document.getElementById('rule-name').value='';
+    document.getElementById('rule-pattern').value='';
+    renderRules();
+});
+renderRules();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- support multiple scanning rules via `RuleScanner`
- track scan results as JSON in `AuditManager`
- allow dynamic rule creation in the web GUI
- add regression test for `RuleScanner`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6841da6fc7fc832cb18ad70e48ccd525