### PR TITLE
Add SQLite storage and results viewer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 saved_plugins/*
-plugin_upload_audit.xlsx__pycache__/
+plugin_upload_audit.xlsx
+__pycache__/
+scan_results.db

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project scans WordPress plugins for upload features.
 - Download plugins from WordPress.org
 - Search plugins by keyword
 - Detect upload-related code
-- Save results to `plugin_upload_audit.xlsx`
+- Save results to `scan_results.db` (SQLite)
 - Optional GUI and web interface
 
 ## Installation
@@ -23,7 +23,7 @@ Options:
 - `--web`: launch the web GUI
 - With no arguments, opens the desktop GUI (requires Tkinter)
 
-Results are stored in Excel and source files are saved under `saved_plugins`.
+Results are stored in a SQLite database (`scan_results.db`) and source files are saved under `saved_plugins`.
 
 Run tests with:
 ```

--- a/README_JP.md
+++ b/README_JP.md
@@ -6,7 +6,7 @@
 - WordPress.orgからプラグインを取得
 - キーワード検索によるプラグイン取得
 - アップロード関連コードの検出
-- 結果は`plugin_upload_audit.xlsx`に保存
+- 結果は`scan_results.db`(SQLite)に保存
 - GUIやWebインターフェースも利用可能
 
 ## インストール
@@ -23,7 +23,7 @@ python main.py [オプション] [スラッグ ...]
 - `--web` : Web GUIを起動
 - 引数無し: Tkinter GUIを起動します
 
-結果は`saved_plugins`フォルダーとExcelファイルに保存されます。
+結果はSQLiteデータベース(`scan_results.db`)と`saved_plugins`フォルダーに保存されます。
 
 テスト実行:
 ```

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ from typing import List
 
 from wp_plugin_scanner.downloader import RequestsDownloader
 from wp_plugin_scanner.scanner import UploadScanner
-from wp_plugin_scanner.reporter import ExcelReporter
+from wp_plugin_scanner.reporter import SQLiteReporter
 from wp_plugin_scanner.searcher import PluginSearcher
 from wp_plugin_scanner.manager import AuditManager
 
@@ -62,7 +62,7 @@ def main(argv: list[str] | None = None) -> int:
         manager = AuditManager(
             RequestsDownloader(),
             UploadScanner(),
-            ExcelReporter(),
+            SQLiteReporter(),
             save_sources=save_flag,
         )
         manager.run(explicit_slugs)

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -9,7 +9,7 @@ import requests
 from wp_plugin_scanner.searcher import PluginSearcher
 from wp_plugin_scanner.manager import AuditManager
 from wp_plugin_scanner.scanner import UploadScanner
-from wp_plugin_scanner.reporter import ExcelReporter
+from wp_plugin_scanner.reporter import SQLiteReporter
 from wp_plugin_scanner.config import SAVE_ROOT
 
 
@@ -36,21 +36,21 @@ class TestArchive(unittest.TestCase):
         shutil.rmtree(SAVE_ROOT, ignore_errors=True)
 
     def test_archive(self):
-        class DummyReporter(ExcelReporter):
+        class DummyReporter(SQLiteReporter):
             def add_result(self, result):
                 pass
 
         mgr = AuditManager(
             downloader=mock.Mock(download=lambda slug: self.tmp / "plug"),
             scanner=UploadScanner(),
-            reporter=DummyReporter(Path(self.tmp / "out.xlsx")),
+            reporter=DummyReporter(Path(self.tmp / "out.db")),
             save_sources=True,
         )
         mgr.run(["demo"])
         self.assertTrue((SAVE_ROOT / "demo/a.php").exists())
 
     def test_progress_callback(self):
-        class DummyReporter(ExcelReporter):
+        class DummyReporter(SQLiteReporter):
             def add_result(self, result):
                 pass
 
@@ -58,7 +58,7 @@ class TestArchive(unittest.TestCase):
         mgr = AuditManager(
             downloader=mock.Mock(download=lambda slug: self.tmp / "plug"),
             scanner=UploadScanner(),
-            reporter=DummyReporter(Path(self.tmp / "out.xlsx")),
+            reporter=DummyReporter(Path(self.tmp / "out.db")),
             save_sources=False,
         )
         mgr.run(["demo"], progress_cb=lambda m: events.append(m))

--- a/wp_plugin_scanner/config.py
+++ b/wp_plugin_scanner/config.py
@@ -5,7 +5,7 @@ DEFAULT_WORKERS = 8
 DEFAULT_RETRIES = 3
 DEFAULT_TIMEOUT = 30
 BACKOFF_FACTOR = 3
-EXCEL_PATH = Path("plugin_upload_audit.xlsx")
+DB_PATH = Path("scan_results.db")
 SAVE_ROOT = Path("saved_plugins")
 MAX_SEARCH_RESULTS = 50
 

--- a/wp_plugin_scanner/gui.py
+++ b/wp_plugin_scanner/gui.py
@@ -7,7 +7,7 @@ from typing import List
 from .manager import AuditManager
 from .downloader import RequestsDownloader
 from .scanner import UploadScanner
-from .reporter import ExcelReporter
+from .reporter import SQLiteReporter
 from .searcher import PluginSearcher
 
 class AuditGUI:
@@ -16,7 +16,7 @@ class AuditGUI:
         self.root.title("WP Plugin Upload Auditor")
         self._build_widgets()
         self.searcher = PluginSearcher()
-        self.mgr = AuditManager(RequestsDownloader(), UploadScanner(), ExcelReporter())
+        self.mgr = AuditManager(RequestsDownloader(), UploadScanner(), SQLiteReporter())
         self.logs: List[str] = []
 
     def _build_widgets(self):

--- a/wp_plugin_scanner/manager.py
+++ b/wp_plugin_scanner/manager.py
@@ -9,14 +9,14 @@ from .config import SAVE_ROOT, DEFAULT_WORKERS
 from .models import PluginResult
 from .downloader import IPluginDownloader
 from .scanner import UploadScanner
-from .reporter import ExcelReporter
+from .reporter import SQLiteReporter
 
 class AuditManager:
     def __init__(
         self,
         downloader: IPluginDownloader,
         scanner: UploadScanner,
-        reporter: ExcelReporter,
+        reporter: SQLiteReporter,
         *,
         save_sources: bool = True,
         max_workers: int = DEFAULT_WORKERS,

--- a/wp_plugin_scanner/templates/results.html
+++ b/wp_plugin_scanner/templates/results.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Scan Results</title>
+    <style>
+        table {border-collapse: collapse; width: 100%;}
+        th, td {border: 1px solid #ccc; padding: 8px; text-align: left;}
+        nav {margin-top: 10px;}
+    </style>
+</head>
+<body>
+<h1>Scan Results</h1>
+<table>
+    <tr><th>Slug</th><th>Status</th><th>Timestamp</th></tr>
+    {% for r in results %}
+    <tr><td>{{ r.slug }}</td><td>{{ r.status }}</td><td>{{ r.readable_time }}</td></tr>
+    {% endfor %}
+</table>
+<nav>
+    {% if page > 1 %}
+        <a href="?page={{ page-1 }}&per_page={{ per_page }}">Prev</a>
+    {% endif %}
+    Page {{ page }} / {{ (total // per_page) + (1 if total % per_page else 0) }}
+    {% if page * per_page < total %}
+        <a href="?page={{ page+1 }}&per_page={{ per_page }}">Next</a>
+    {% endif %}
+</nav>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- store scan results in `scan_results.db`
- drop Excel reporter in favor of `SQLiteReporter`
- update CLI and GUI to use SQLite storage
- add new `/results` page to view scans with pagination
- document new SQLite result storage

## Testing
- `pip install -r requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684ac3851d1c832c985945ffa2912a6c